### PR TITLE
Feat move base

### DIFF
--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -42,6 +42,7 @@ public:
                 std::string message_type = data["type"].get<std::string>();
 
                 if (message_type == "link_setpoints") {
+                    arm_.setMoveModeSetJoints(true);
                     if (data["data"].is_array()) {
                         // Handle array of {link_name, value}
                         for (const auto& movable_link : data["data"]) {
@@ -69,6 +70,7 @@ public:
                     std::cerr << "Invalid JSON: Expected array" << std::endl;
                     }
                 } else if (message_type == "goal_setpoints") {
+                    arm_.setMoveModeSetJoints(false);
                     if (data["data"].contains("goal_pose")) {
                         const auto& goal_pose = data["data"]["goal_pose"];
                         if (goal_pose.contains("x") && goal_pose.contains("y") && 
@@ -98,6 +100,7 @@ public:
                         std::cerr << "Invalid goal_setpoints: Missing goal_pose" << std::endl;
                     }
                 } else if (message_type == "move_base_setpoints") {
+                    arm_.setMoveModeSetJoints(false);
                     if (data["data"].contains("goal_pose")) {
                         const auto& goal_pose = data["data"]["goal_pose"];
                         if (goal_pose.contains("x") && goal_pose.contains("y") && 

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -59,7 +59,7 @@ public:
                                             link.getLinkType() == RobotLink::LinkType::ROT_Z) {
                                             value = value * M_PI / 180.0f; // convert to radians
                                         }
-                                        link.setRequestedValue(value);
+                                        link.setRequestedPosition(value);
                                         break;
                                     }
                                 }

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -89,15 +89,37 @@ public:
                             // Compute the inverse kinematics
                             arm_.computeJointAngles(x, y, rotz);
 
-
                         } else {
                             std::cerr << "Invalid goal_setpoints: Missing x, y, z, or rotz" << std::endl;
                         }
                     } else {
                         std::cerr << "Invalid goal_setpoints: Missing goal_pose" << std::endl;
                     }
-                }
-                else {
+                } else if (message_type == "move_base_setpoints") {
+                    if (data["data"].contains("goal_pose")) {
+                        const auto& goal_pose = data["data"]["goal_pose"];
+                        if (goal_pose.contains("x") && goal_pose.contains("y") && 
+                            goal_pose.contains("z") && goal_pose.contains("rotz")) {
+                            float x = goal_pose["x"].get<float>();
+                            float y = goal_pose["y"].get<float>();
+                            float z = goal_pose["z"].get<float>();
+                            float rotz = goal_pose["rotz"].get<float>();
+                            // Convert rotz from degrees to radians
+                            rotz = rotz * M_PI / 180.0f;
+                            std::cout << "Received move_base_setpoints: x=" << x << ", y=" << y 
+                                      << ", z=" << z << ", rotz=" << rotz << " rad" << std::endl;
+                            // Set the move_base goal pose in the robotic arm
+                            arm_.setMoveBaseGoalPose(x, y, z, rotz);
+
+                            arm_.moveBase();
+
+                        } else {
+                            std::cerr << "Invalid move_base_setpoints: Missing x, y, z, or rotz" << std::endl;
+                        }
+                    }
+                    
+
+                } else {
                     std::cerr << "Unknown message type: " << message_type << std::endl;
                 }
             } catch (const std::exception& e) {

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -82,12 +82,14 @@ public:
                             std::cout << "Received goal_setpoints: x=" << x << ", y=" << y 
                                       << ", z=" << z << ", rotz=" << rotz << " rad" << std::endl;
                             // Set the goal pose in the robotic arm
-                            arm_.setGoalPose(x, y, z, rotz);
+                            arm_.setGoalPoseWorld(x, y, z, rotz);
+                            
                             // Get the arm lengths
                             // float arm1_length, arm2_length, arm3_length;
                             // arm_.getLinkLengths(arm1_length, arm2_length, arm3_length, "arm1", "arm2", "arm3");
                             // Compute the inverse kinematics
-                            arm_.computeJointAngles(x, y, rotz);
+                            // arm_.computeJointAngles(x, y, rotz);
+                            arm_.moveBase();
 
                         } else {
                             std::cerr << "Invalid goal_setpoints: Missing x, y, z, or rotz" << std::endl;

--- a/backend/src/robot.hpp
+++ b/backend/src/robot.hpp
@@ -41,6 +41,11 @@ struct MoveBase
     Velocity velocity;
 };
 
+float getAngleDifference(float angle1, float angle2)
+{
+    float diff = angle2 - angle1;
+    return std::remainder(diff, 2.0f * M_PI);
+}
 class RobotLink
 {
 public:
@@ -620,10 +625,10 @@ public:
         // Choose the solution closest to the current angles
         float min_distance = std::numeric_limits<float>::max();
         int best_solution = 0;
-        for (int i = 0; i < 2; ++i) {   // TODO: Here I should check for wrapping around
-            float distance = std::pow(solutions[i].rot1 - current_rot1, 2) +
-                            std::pow(solutions[i].rot2 - current_rot2, 2) +
-                            std::pow(solutions[i].rot3 - current_rot3, 2);
+        for (int i = 0; i < 2; ++i) {
+            float distance = std::pow(getAngleDifference(solutions[i].rot1, current_rot1), 2) +
+                            std::pow(getAngleDifference(solutions[i].rot2, current_rot2), 2) +
+                            std::pow(getAngleDifference(solutions[i].rot3, current_rot3), 2);
             if (distance < min_distance) {
                 min_distance = distance;
                 best_solution = i;

--- a/backend/src/robot.hpp
+++ b/backend/src/robot.hpp
@@ -24,6 +24,13 @@ private:
     float Kd; // Derivative gain
 };
 
+struct MoveBase
+{
+    float x = 0.0f, y = 0.0f, z = 0.0f;           
+    float rot_x = 0.0f, rot_y = 0.0f, rot_z = 0.0f;
+    float vel_x = 0.0f, vel_y = 0.0f, vel_z = 0.0f;
+};
+
 class RobotLink
 {
 public:
@@ -35,7 +42,8 @@ public:
         Z,      // Translation along Z
         ROT_X,  // Rotation around X
         ROT_Y,  // Rotation around Y
-        ROT_Z   // Rotation around Z
+        ROT_Z,  // Rotation around Z
+        Move_Base // Move base. Make different type so it does not show up in UI
     };
 
     // Constructor
@@ -265,6 +273,8 @@ private:
             return "ROT_Y";
         case LinkType::ROT_Z:
             return "ROT_Z";
+        case LinkType::Move_Base:
+            return "Move_Base";
         default:
             return "UNKNOWN";
         }
@@ -279,6 +289,8 @@ public:
         // Hardcode robot: base (STATIC), arm1 (ROT_Z), arm2 (ROT_Z)
         // Entities in links: translation x, y z, rotation x, y, z, type, min, max, speed, acceleration
         links = {
+            RobotLink("move_base_x", 0.0f, 0.0f, 1.5f, 0.0f, 0.0f, 0.0f,
+                      RobotLink::LinkType::Move_Base, 0.0, 0.0f, 0.0f, 0.0f),     
             // Base: 1.5m tall, 0.3m x 0.3m
             RobotLink("base", 0.0f, 0.0f, 1.5f, 0.0f, 0.0f, 0.0f,
                       RobotLink::LinkType::Z, 1.0f, 2.0f, 0.2f, 0.2f),
@@ -332,6 +344,25 @@ public:
         goal_y = y;
         goal_z = z;
         goal_rot_z = rotz; // should already be in radians
+    }
+
+    void setMoveBaseGoalPose(float x, float y, float z, float rotz)
+    {
+        move_base_goal.x = x;
+        move_base_goal.y = y;
+        move_base_goal.z = z;
+        move_base_goal.rot_z = rotz; // should already be in radians
+    }
+
+    void moveBase()
+    {
+        // step 1: express the goal position in the base frame
+
+        // step 2: with this position, call the computeJointAngles function
+
+        // optional step 2.5: get base velocity and compute velocity feed foward for joints.
+
+        // step 3: move the base and check again next time step.
     }
 
     // Getter specifically for Monumental Robot with 3 arms
@@ -477,6 +508,9 @@ private:
     // store the goal pose
     float goal_x, goal_y, goal_z;   // meters
     float goal_rot_z;                // radians
+    // set current position ov base
+    MoveBase move_base = {};        // position and rotation of the base
+    MoveBase move_base_goal = {};   // goal position and rotation of the base. Ignore velocity.
 };
 
 #endif

--- a/backend/src/robot.hpp
+++ b/backend/src/robot.hpp
@@ -284,7 +284,7 @@ private:
     float currentPosition;                             // Current position (m or rad)
     float requestedPosition;                           // Requested position (m or rad)
     float currentVelocity;                         // m/s or rad/s
-    float feedForwardVelocity;                     // m/s or rad/s
+    float feedForwardVelocity=0;                     // m/s or rad/s
     float prevPosError;                            // Previous position error
     float prevVelError;                            // Previous velocity error
     PDController posController;                    // Position PD controller
@@ -354,7 +354,10 @@ public:
     void update()
     {
         float dt = getUpdateInterval() / 1000.0f; // Convert ms to seconds
-        moveBase(); // move the base
+        if (!move_mode_set_joints){
+            moveBase(); // move the base
+        }
+            
         for (auto &link : links)
         {
             // link.moveAroundZAxis();
@@ -721,6 +724,7 @@ public:
     std::vector<RobotLink> &getLinks() { return links; } // TODO: make const, for now like this to set the requested value
 
     int getUpdateInterval() const { return update_interval_ms; }
+    void setMoveModeSetJoints(bool mode) { move_mode_set_joints = mode; }
 
 private:
     std::vector<RobotLink> links;
@@ -735,6 +739,7 @@ private:
     Pose move_base_goal = {};   // goal position and rotation of the base. Ignore velocity.
     float move_base_velocity = 0.2f; // m/s
     float move_base_rotation = 0.5f; // rad/s
+    bool move_mode_set_joints = true; // true if move mode is set to joints, false if set to base  
 };
 
 #endif

--- a/backend/src/robot.hpp
+++ b/backend/src/robot.hpp
@@ -132,6 +132,8 @@ public:
         if (type == LinkType::STATIC) return 0.0f;
         // Position controller: outputs velocity reference
         float pos_error = pos_ref - pos_actual;
+        pos_error = fmod(pos_error + M_PI, 2 * M_PI) - M_PI; // take into account wrapping
+
         // float pos_error_deriv = (pos_error - prevPosError) / dt;
         // instead of using the derivative of the position error, use the velocity
         float pos_error_deriv = -vel_actual; // I think the sign should be negative
@@ -366,6 +368,14 @@ public:
         goal_rot_z = rotz; // should already be in radians
     }
 
+    void setGoalPoseWorld(float x, float y, float z, float rotz)
+    {
+        goal_pose_world.x = x;
+        goal_pose_world.y = y;
+        goal_pose_world.z = z;
+        goal_pose_world.rot_z = rotz; // should already be in radians
+    }
+
     void setMoveBaseGoalPose(float x, float y, float z, float rotz)
     {
         move_base_goal.x = x;
@@ -387,11 +397,11 @@ public:
         }
         
         // step 1: express the goal position in the base frame
-        Pose goal_pose_world; // ugly, use Pose object perhaps later.
-        goal_pose_world.x = goal_x;
-        goal_pose_world.y = goal_y;
-        goal_pose_world.z = goal_z;
-        goal_pose_world.rot_z = goal_rot_z;
+        // Pose goal_pose_world; // ugly, use Pose object perhaps later.
+        // goal_pose_world.x = goal_x;
+        // goal_pose_world.y = goal_y;
+        // goal_pose_world.z = goal_z;
+        // goal_pose_world.rot_z = goal_rot_z;
         Pose goal_pose_wrt_robot = convertGoalPoseInBaseFrame(goal_pose_world);
 
         // print
@@ -578,9 +588,11 @@ public:
 private:
     std::vector<RobotLink> links;
     int update_interval_ms = 100; // 100ms update interval
-    // store the goal pose
+    // store the goal pose (robot frame)
     float goal_x, goal_y, goal_z;   // meters
     float goal_rot_z;                // radians
+    // store goal pose (world frame)
+    Pose goal_pose_world = {};
     // set current position ov base
     MoveBase move_base = {};        // position and rotation of the base
     Pose move_base_goal = {};   // goal position and rotation of the base. Ignore velocity.

--- a/frontend/src/main_links.ts
+++ b/frontend/src/main_links.ts
@@ -63,8 +63,10 @@ ws.onmessage = (event: MessageEvent) => {
         default:
           stateText = 'Unknown';
       }
-      stateP.innerHTML = `${link.link_name}: <span id="state-${link.link_name}">${stateText}</span>`;
-      stateDiv.appendChild(stateP);
+      if (link.movable !== 'Move_Base') { // Avoid displaying movable base
+        stateP.innerHTML = `${link.link_name}: <span id="state-${link.link_name}">${stateText}</span>`;
+        stateDiv.appendChild(stateP);
+      }
     });
 
 
@@ -198,6 +200,19 @@ sendGoalButton.addEventListener('click', () => {
   };
   ws.send(JSON.stringify({ type: 'goal_setpoints', data: { goal_pose: goalPose } }));
   console.log('Sent goal_setpoints:', goalPose);
+});
+
+// Send Move Base button handler
+const sendMoveBaseButton = document.getElementById('move_base') as HTMLButtonElement;
+sendMoveBaseButton.addEventListener('click', () => {
+  const baseGoalPose: GoalPose = {
+    x: parseFloat((document.getElementById('base-x') as HTMLInputElement).value) || 0,
+    y: parseFloat((document.getElementById('base-y') as HTMLInputElement).value) || 0,
+    z: parseFloat((document.getElementById('base-z') as HTMLInputElement).value) || 0,
+    rotz: parseFloat((document.getElementById('base-rotz') as HTMLInputElement).value) || 0
+  };
+  ws.send(JSON.stringify({ type: 'move_base_setpoints', data: { goal_pose: baseGoalPose } }));
+  console.log('Sent goal_setpoints:', baseGoalPose);
 });
 
 ws.onerror = (error: Event) => console.error('WebSocket error:', error);

--- a/frontend/src/main_links.ts
+++ b/frontend/src/main_links.ts
@@ -73,7 +73,7 @@ ws.onmessage = (event: MessageEvent) => {
     // Generate controls only once
     if (!controlsInitialized) {
       links.forEach((link, index) => {
-        if (link.movable !== 'STATIC') {
+        if (link.movable !== 'STATIC' && link.movable !== 'Move_Base') {
           const controlP = document.createElement('p');
           // make distinction between translation and rotation
           if (link.movable === 'X' || link.movable === 'Y' || link.movable === 'Z') {
@@ -177,7 +177,7 @@ ws.onmessage = (event: MessageEvent) => {
 const sendAllButton = document.getElementById('send-all') as HTMLButtonElement;
 sendAllButton.addEventListener('click', () => {
   const requests = links
-    .filter(link => link.movable !== 'STATIC')
+    .filter(link => link.movable !== 'STATIC' && link.movable !== 'Move_Base')
     .map(link => {
       const input = document.getElementById(`input-${link.link_name}`) as HTMLInputElement;
       const value = parseFloat(input.value);


### PR DESCRIPTION
Add functionality to move the base. 

- Base moves with linear velocity, not via feedback control. This causes high accelerations at beginning and start, so this was perhaps a mistake.
- Add feedforward in the actuator controllers. While the base is moving, we use inverse kinematics to compute a feedforward component for each moving joint. This makes the position error disappear as the base is moving! However, the initial and final acceleration of the base still cause an error.
- Fix some bugs along the way.