### PR TITLE
Fix move base error

### DIFF
--- a/backend/include/robot_arm.hpp
+++ b/backend/include/robot_arm.hpp
@@ -56,7 +56,7 @@ private:
     utils::MoveBase move_base = {};     // position and rotation of the base
     utils::Pose move_base_goal = {};    // goal position and rotation of the base. Ignore velocity.
     float move_base_velocity = 0.2f;    // m/s
-    float move_base_rotation = 0.5f;    // rad/s
+    float move_base_rotation = 0.2f;    // rad/s
     bool move_mode_set_joints = true;   // true if move mode is set to joints, false if set to base  
 };
 

--- a/backend/include/robot_link.hpp
+++ b/backend/include/robot_link.hpp
@@ -43,6 +43,7 @@ public:
               LinkType type, float minVal, float maxVal, float maxSpeed, float maxAcc);
 
     // Getters
+    utils::Pose getPose();
     float getTranslationX() const { return translationX; }
     float getTranslationY() const { return translationY; }
     float getTranslationZ() const { return translationZ; }

--- a/backend/src/robot_link.cpp
+++ b/backend/src/robot_link.cpp
@@ -58,6 +58,17 @@ void RobotLink::setPose(utils::Pose pose) {
     rotationZ = pose.rot_z;
 }
 
+utils::Pose RobotLink::getPose() {
+    utils::Pose pose;
+    pose.x = translationX;
+    pose.y = translationY;
+    pose.z = translationZ;
+    pose.rot_x = rotationX;
+    pose.rot_y = rotationY;
+    pose.rot_z = rotationZ;
+    return pose;
+}
+
 // Compute acceleration for velocity tracking
 float RobotLink::computeVelocityControl(float vel_ref, float dt) {
     if (type == LinkType::STATIC) return 0.0f;

--- a/backend/src/websocket_server.cpp
+++ b/backend/src/websocket_server.cpp
@@ -85,8 +85,6 @@ void WebSocketServer::handleGoalSetpoints(const json& data) {
                       << ", z=" << z << ", rotz=" << rotz << " rad" << std::endl;
             // Set the goal pose in the robotic arm
             arm_.setGoalPoseWorld(x, y, z, rotz);
-            // TODO: I think this is not required. This function is called in the arm.update() function
-            arm_.moveBase();
         } else {
             std::cerr << "Invalid goal_setpoints: Missing x, y, z, or rotz" << std::endl;
         }
@@ -111,8 +109,6 @@ void WebSocketServer::handleMoveBaseSetpoints(const json& data) {
                       << ", z=" << z << ", rotz=" << rotz << " rad" << std::endl;
             // Set the move_base goal pose in the robotic arm
             arm_.setMoveBaseGoalPose(x, y, z, rotz);
-            // TODO: I think this is not required. This function is called in the arm.update() function
-            arm_.moveBase();
         } else {
             std::cerr << "Invalid move_base_setpoints: Missing x, y, z, or rotz" << std::endl;
         }


### PR DESCRIPTION
There was still an issue with the move_base link. While I always apply first rotation and then translation, here I wanted it to be the other way round. The way to fix this was to split up my move base link in 2 links. First a translation, then a rotation. This works.